### PR TITLE
Defer storage policy to brc-knowledge; trim HIBERNATION; cold-start handoff

### DIFF
--- a/HIBERNATION.md
+++ b/HIBERNATION.md
@@ -1,158 +1,56 @@
-# Clyfar Hibernation Runbook (Ops Pause -> Dev Mode)
-Date updated: 2026-03-30
+# Clyfar Hibernation Runbook
+Last updated: 2026-05-13
 
-This file is the durable handoff for seasonal operations pause. It explains what was changed, how to restore production cron behavior, how to test restarts safely, and what to prioritize in dev mode.
+Durable handoff for the seasonal Clyfar pause. v1.1 dev-mode roadmap moved to [`docs/v1.1-roadmap.md`](docs/v1.1-roadmap.md).
 
-## What was changed today (plain language)
+## Current intended cron state
 
-The user crontab was checked and it contained two active jobs:
-- observation downloader every 5 minutes
-- Clyfar 6-hourly forecast submit job
-
-Only the Clyfar submit line was commented out. The observation job stayed active.
-
-### Current intended state
+The observation downloader stays active; the 6-hourly Clyfar submit is paused.
 
 ```cron
-# Observations - Every 5 minutes (ACTIVE)
+# Observations - every 5 minutes (ACTIVE)
 */5 * * * * /bin/bash -c 'source ~/.bashrc_basinwx && source ~/software/pkg/miniforge3/etc/profile.d/conda.sh && conda activate clyfar-nov2025 && python ~/gits/brc-tools/brc_tools/download/get_map_obs.py >> ~/logs/obs.log 2>&1'
 
 # Clyfar 6-hourly submits (PAUSED)
 # 15 3,9,15,21 * * * /bin/bash -c 'source ~/.bashrc_basinwx && export PATH=$PATH:/uufs/notchpeak.peaks/sys/installdir/slurm/std/bin && cd ~/gits/clyfar && sbatch scripts/submit_clyfar.sh >> ~/logs/clyfar_submit.log 2>&1'
 ```
 
-## How to inspect and confirm (safe checks)
+## Inspect
 
 ```bash
-# Show crontab with line numbers
 crontab -l | nl -ba
-
-# Optional quick sanity checks
 rg -n "Observations|submit_clyfar.sh" <(crontab -l)
 ```
 
-Operational check interpretation:
-- Observation line should be uncommented.
-- Clyfar line should be present but commented out during hibernation.
+Observation line should be uncommented; Clyfar line should be present but commented.
 
-## Return to normal (resume 6-hourly forecasts)
+## Resume forecasts
 
-1. Edit crontab:
-```bash
-crontab -e
-```
+1. `crontab -e` and remove the leading `#` from the Clyfar line.
+2. Re-check with `crontab -l | nl -ba`.
+3. Optional smoke submit: `cd ~/gits/clyfar && sbatch scripts/submit_clyfar.sh`.
+4. Verify first cycle: `rg -n "Running Clyfar forecast for init time|STATUS_FORECAST_EXPORT|STATUS_LLM_STAGE" ~/logs/basinwx/clyfar_*.out ~/logs/basinwx/clyfar_*.err`.
 
-2. Remove the leading `#` from the Clyfar line.
-
-3. Re-check:
-```bash
-crontab -l | nl -ba
-```
-
-4. Optional smoke submit before waiting for cron:
-```bash
-cd ~/gits/clyfar
-sbatch scripts/submit_clyfar.sh
-```
-
-5. Verify first resumed cycle:
-```bash
-rg -n "Running Clyfar forecast for init time|STATUS_FORECAST_EXPORT|STATUS_LLM_STAGE" ~/logs/basinwx/clyfar_*.out ~/logs/basinwx/clyfar_*.err
-```
-
-## Tweak behavior without breaking commands
-
-Keep command bodies unchanged whenever possible. Only edit cron schedule fields.
-
-Examples:
+## Tweak schedule (cadence only — keep command body intact)
 
 ```cron
-# Every 6 hours at :15 local scheduler time (current operational style)
-15 3,9,15,21 * * *
-
-# Every 12 hours at :15
-15 3,15 * * *
-
-# Daily at 03:15
-15 3 * * *
+15 3,9,15,21 * * *   # every 6 hours at :15 (current operational)
+15 3,15 * * *        # every 12 hours
+15 3 * * *           # daily 03:15
 ```
 
-If you change cadence, keep `scripts/submit_clyfar.sh` as the invoked entrypoint so init anchoring and downstream behavior remain consistent.
+Keep `scripts/submit_clyfar.sh` as the entrypoint so init anchoring and downstream behavior stay consistent.
 
-## Backup/rollback pattern (recommended)
+## Backup / rollback
 
-Before manual edits:
 ```bash
+# Before manual edits
 crontab -l > /tmp/clyfar_crontab.backup.$(date +%Y%m%d_%H%M%S)
-```
 
-Rollback:
-```bash
+# Rollback
 crontab /tmp/clyfar_crontab.backup.YYYYMMDD_HHMMSS
 ```
 
-## Repo state snapshot for milestone planning
+## Entry points for agents
 
-Current repo version:
-- `__init__.__version__`: `1.0.6`
-
-Current label set (GitHub issues/PR labels):
-- `bug`
-- `documentation`
-- `duplicate`
-- `enhancement`
-- `good first issue`
-- `help wanted`
-- `invalid`
-- `question`
-- `wontfix`
-- `potential bug`
-
-Current git tags include:
-- Clyfar tags through `v1.0.6`
-- Ffion tags through `ffion-v1.1.3`
-- LLM/pipeline milestone tags (`ai-llm-v*`, `llm-v*`)
-
-If you want to signal this hibernation milestone without changing Ffion:
-- bump only `__init__.__version__` (Clyfar axis)
-- create a matching git tag (`vX.Y.Z`) after merge
-- keep `utils/versioning.py` unchanged unless Ffion bundle changes
-
-## Dev-mode roadmap (prioritized micro-items)
-
-Scoring word: **Leverage** (10 = highest leverage)
-
-### Important / urgent
-- **Leverage 10/10** — Freeze operational runtime into a pinned deployment path (non-mutable checkout) and run ops from that path only.
-- **Leverage 10/10** — Split “ops” and “dev” trees (worktree or clone) so development cannot perturb live scheduling environments.
-- **Leverage 9.5/10** — Create a one-command replay harness for historical cycles (download, run, export, validate markers) for deterministic retrospective evaluation.
-- **Leverage 9.5/10** — Add automated scorecard generation (event-based precision/recall, calibration curves, regime slices) from archived forecasts/obs.
-- **Leverage 9/10** — Build a baseline-vs-candidate comparison runner for `v0p9` versus `v1.1+` rule sets with standardized metrics and artifact paths.
-- **Leverage 9/10** — Harden cache lifecycle controls (fresh-cache option, per-job cache isolation, corruption detection, and cleanup hooks).
-- **Leverage 8.5/10** — Add a strict “no upload” dev profile and CI-like local gate checks for export/LLM paths to avoid accidental production side effects.
-- **Leverage 8.5/10** — Create a reproducible data manifest per run (inputs, hashes, versions, run config) for exact reruns and science traceability.
-- **Leverage 8/10** — Define and enforce objective promotion criteria for version bumps (`v1.0.x -> v1.1.0`) tied to measurable gains.
-- **Leverage 8/10** — Consolidate operational triage commands into one script with clear pass/fail output and suggested remediations.
-
-### Cool / useful / fruitful
-- **Leverage 7.5/10** — Add lightweight dashboard notebooks/scripts that summarize seasonal skill by episode type (stagnation, frontal clearing, snowpack states).
-- **Leverage 7.5/10** — Introduce parameter sweep tooling for membership-function/rule tuning with reproducible experiment manifests.
-- **Leverage 7/10** — Build a “known-bad cases” benchmark suite to stress-test logic changes before merging.
-- **Leverage 7/10** — Add changelog automation that groups operational, science, and LLM/Ffion impacts per release.
-- **Leverage 6.5/10** — Standardize failure taxonomy and marker vocabulary so postmortems and trend analysis are machine-queryable.
-- **Leverage 6.5/10** — Add synthetic dry-run fixtures for upstream outage simulation (GEFS missing files, upload auth failures, delayed scheduler starts).
-- **Leverage 6/10** — Produce concise architecture diagrams for dataflow and failure domains to speed onboarding of new contributors/agents.
-- **Leverage 6/10** — Create “season startup checklist” and “season shutdown checklist” scripts to reduce manual drift each year.
-
-## Suggested milestone next step
-
-If this hibernation handoff is accepted, consider:
-- keep Clyfar at `1.0.6` as the hibernation baseline
-- run 2025/2026 reforecast evaluation with this baseline for the preprint
-- start a `v1.1` project board keyed to the top 10 leverage items above
-
-## AI-agent note
-
-For AI agents entering this repo:
-- read `AGENTS.md` and `docs/README.md` first
-- then read this file for current operational state before proposing schedule or deployment changes
+Read `AGENTS.md` and `docs/README.md` first, then this file for current operational state before proposing any schedule or deployment change. Storage policy lives in [`docs/STORAGE-GUIDE.md`](docs/STORAGE-GUIDE.md), which defers to the brc-knowledge CHPC team resource inventory.

--- a/docs/STORAGE-GUIDE.md
+++ b/docs/STORAGE-GUIDE.md
@@ -1,31 +1,31 @@
 # Clyfar Storage Guide
 
-Quick reference for CHPC storage locations, policies, and archival strategy.
-For the v1.0.6 smoke and winter-rerun handoff, use
-[`docs/chpc-v106-dry-run.md`](chpc-v106-dry-run.md).
+Clyfar-specific storage layout and archival workflow. **Quota numbers, mount paths, and CHPC-wide policy live in the durable team reference** — this doc deliberately does not restate them so they cannot drift.
 
----
+## Canonical reference
 
-## Storage Locations
-
-| Location | Capacity | Auto-Purge | Use For |
-|----------|----------|------------|---------|
-| `/scratch/general/vast/` | 50 TB/user | **60 days** | Active runs, GRIB cache |
-| Cottonwood (`lawson-group5`) | 16 TiB | Never | Archived runs, reference data |
-| Home (`~/`) | 7.3 GiB | Never | Code, configs only |
-| `/scratch/local/` | Node-local | **Reboot + 2 weeks** | Job temp files |
-| `/tmp/` | Small | **Reboot** | Lock files only |
-
-**Warning:** Scratch is scrubbed weekly. Files not accessed for >60 days are deleted.
-
-Source: [CHPC File Storage Policies](https://www.chpc.utah.edu/documentation/policies/3.1FileStoragePolicies.php)
-
----
-
-## Output Directory Structure
+For CHPC quotas, mount paths, autofs caveats, owned-node terms, and the Lawson-group storage best-practice workflow:
 
 ```
-/scratch/general/vast/clyfar_test/v0p9/
+~/gits/brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md
+```
+
+That file is the source of truth for: home/scratch/group quotas, the `lawson-group{4,5,6}` tier (group6 is currently the active archive store; group5 has shown autofs faults), the 60-day atime-based scratch purge, and the recommended scratch-first workflow.
+
+If you are about to archive or stage data, **smoke-test the mount first**:
+
+```bash
+df -hT /uufs/chpc.utah.edu/common/home/lawson-group{4,5,6} 2>&1
+```
+
+A `Too many levels of symbolic links` result means autofs has faulted on this node — try another node before assuming the volume is gone.
+
+## Clyfar output tree
+
+Same structure under scratch (active runs) and under the chosen Cottonwood archive root (durable):
+
+```
+clyfar/v0p9/
 └── YYYYMMDDHH/
     ├── parquet/
     │   ├── timeseries/       # GEFS station time series
@@ -33,35 +33,31 @@ Source: [CHPC File Storage Policies](https://www.chpc.utah.edu/documentation/pol
     ├── figures/
     │   ├── heatmaps/         # Possibility heatmaps
     │   ├── meteograms/       # Station plots
-    │   └── synoptic/         # Future: 600hPa maps, etc.
+    │   └── synoptic/         # Future: 600 hPa maps, etc.
     └── json/
         └── basinwx_export/   # Website JSON
 ```
 
-Same structure for archive on Cottonwood.
+## Archive vs delete
 
----
+**Archive** (copy from scratch to `lawson-group6/clyfar/archive/`):
 
-## What to Archive vs Delete
+- `parquet/dailymax/` — aggregated results
+- `parquet/timeseries/` — methodology data
+- `figures/heatmaps/` — publication-ready
+- `metadata.json` — run configuration
 
-**Archive (to Cottonwood):**
-- `parquet/dailymax/` - aggregated results
-- `parquet/timeseries/` - methodology data
-- `figures/heatmaps/` - publication-ready
-- `metadata.json` - run configuration
+**Delete** (regenerable from GEFS/Herbie):
 
-**Delete (regenerable):**
-- Full GRIB files (re-downloadable)
+- Full GRIB files
 - Full gridded parquet
 - Intermediate figures
 - cfgrib index files
 
----
-
-## Quick Commands
+## Quick commands
 
 ```bash
-# Check storage usage
+# Local inventory (sizes, run counts, archive-base mount check)
 scripts/storage_inventory.sh
 
 # Interactive cleanup
@@ -70,28 +66,22 @@ scripts/storage_inventory.sh --clean
 # Clear Herbie cache
 rm -rf /scratch/general/vast/$USER/clyfar/herbie_cache/*
 
-# Check home quota
-df -h ~
+# Archive a run (group6 is the current active store; verify mount first)
+df -hT /uufs/chpc.utah.edu/common/home/lawson-group6 \
+  && cp -r /scratch/general/vast/$USER/clyfar/v0p9/YYYYMMDDHH \
+           /uufs/chpc.utah.edu/common/home/lawson-group6/clyfar/archive/
 
-# Archive a run to Cottonwood
-cp -r /scratch/general/vast/clyfar_test/v0p9/YYYYMMDDHH \
-      /uufs/chpc.utah.edu/common/home/lawson-group5/clyfar/archive/
+# Override archive base for storage_inventory.sh (e.g., to point at group5 if group6 is faulted)
+CLYFAR_ARCHIVE_BASE=/uufs/chpc.utah.edu/common/home/lawson-group5/clyfar \
+  scripts/storage_inventory.sh
 ```
 
----
+## Known follow-ups
 
-## Future: Automation
-
-Not yet implemented:
-- Cron-based archival of old runs
-- Auto-cleanup of Herbie cache
-- Alerts before 60-day purge deadline
-- Quota monitoring
-
----
+- `scripts/submit_clyfar.sh` currently defaults `DATA_ROOT=$HOME/basinwx-data/clyfar`, which writes active-run data into `$HOME` instead of scratch. The script honors `DATA_ROOT` / `FIG_ROOT` / `EXPORT_DIR` env overrides today; a future change should flip the default to `/scratch/general/vast/$USER/clyfar` with a post-run rsync to group6.
+- No automated archival, Herbie-cache cleanup, or pre-purge alerting yet.
 
 ## Sources
 
+- `~/gits/brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md` (canonical)
 - [CHPC File Storage Policies](https://www.chpc.utah.edu/documentation/policies/3.1FileStoragePolicies.php)
-- [CHPC Storage Services](https://www.chpc.utah.edu/resources/storage_services.php)
-- `brc-tools/docs/CHPC-REFERENCE.md`

--- a/docs/handoff-reforecast-prep.md
+++ b/docs/handoff-reforecast-prep.md
@@ -1,0 +1,211 @@
+# Cold-start handoff: reforecast-prep plan
+Date written: 2026-05-13
+Audience: the next session (human or agent) starting cold on Clyfar reforecast prep.
+
+This is the **near-term action plan** to take Clyfar from "hibernating with a known storage-policy violation" to "able to run reforecast sweeps end-to-end on scratch with durable outputs on Cottonwood." It is intentionally scoped to the prerequisites *before* a real winter reforecast run begins. Long-term v1.1 work lives in [`v1.1-roadmap.md`](v1.1-roadmap.md); seasonal pause/resume mechanics live in [`../HIBERNATION.md`](../HIBERNATION.md); the existing storage-safe smoke recipe lives in [`chpc-v106-dry-run.md`](chpc-v106-dry-run.md).
+
+## Context (what just happened)
+
+On 2026-05-13 (commit `9f71927` on `main`):
+
+- `docs/STORAGE-GUIDE.md` rewritten thin. The canonical CHPC reference is now `~/gits/brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md` — quotas, mounts, autofs caveats, owned-node terms all live there. **Do not restate quota numbers in Clyfar docs**; they drift.
+- `HIBERNATION.md` trimmed from 160 to 56 lines (runbook only); the 16-item dev roadmap moved to `docs/v1.1-roadmap.md`.
+- `scripts/storage_inventory.sh`: archive base now `CLYFAR_ARCHIVE_BASE`-configurable with `lawson-group6` default; scratch defaults are `/scratch/general/vast/$USER/clyfar`; added a mount smoke-test that warns (no-fails) when the configured Cottonwood volume is autofs-faulted on the current node.
+- `scripts/submit_clyfar.sh`: **TODO(policy)** comment above the `DATA_ROOT` default — flagging that the operational submit script still writes active-run data to `$HOME/basinwx-data/clyfar` against the stated policy. **Behavior is unchanged.** That's the next change.
+
+So: storage *docs* are now correct and policy is unambiguous. Storage *code* still violates the policy in one important spot (`DATA_ROOT`) and one likely spot (`brc-tools/get_map_obs.py`). The plan below fixes both before any real reforecast loop runs.
+
+## Constraints the cold-start session needs to know
+
+1. **`main` is protected.** A push to `main` works only because the human user has bypass permission; routine work belongs on a feature branch with a PR. Default: branch off `main` for the changes below.
+2. **lawson-group6 is the active Cottonwood store** (group5 had autofs faults from `notch392` on 2026-05-13). Always smoke-test the mount with `df -hT /uufs/chpc.utah.edu/common/home/lawson-group6` before staging or archiving. If group6 is faulted on the current node, try a different node before re-pointing at group5.
+3. **Reforecast invocation pattern.** `scripts/submit_clyfar.sh` accepts `$1 = YYYYMMDDHH` as an explicit init time and `--no-retry` to disable transient-failure resubmission (codes 75–79). Reforecasts always specify an explicit init; never auto-detect.
+4. **Upload guard.** `CLYFAR_ENABLE_UPLOAD=0` disables all uploads to BasinWx (forecast JSON, figures, LLM PDF). Reforecasts must run with this set so no historical cycle pollutes the website. `CLYFAR_SKIP_INTERNAL_EXPORT=1` is the default and should stay.
+5. **Cron stays paused.** Reforecasts are batch-launched on demand; do not edit the user crontab. The hibernation runbook describes the cron state to preserve.
+6. **Conda env: `clyfar-nov2025`.** `texlive` lives at `/uufs/chpc.utah.edu/sys/installdir/texlive/2022/bin/x86_64-linux`; `claude` CLI at `~/.local/bin/claude`. These are added by `submit_clyfar.sh` itself; don't duplicate them at the wrapper layer.
+
+## Micro-step plan
+
+### Step 1 — Branch and inventory pre-existing $HOME data (read-only)
+
+```bash
+cd ~/gits/clyfar
+git checkout -b reforecast-prep
+du -sh ~/basinwx-data/clyfar 2>/dev/null
+find ~/basinwx-data/clyfar -maxdepth 2 -type d -name "20*" 2>/dev/null | sort | head
+df -hT /uufs/chpc.utah.edu/common/home/lawson-group6
+```
+
+Goal: confirm what's already sitting in `$HOME/basinwx-data/clyfar`. If there are recent cycles there that the operator wants to keep, a one-time rsync to `lawson-group6/clyfar/archive/` is the cleanest path *before* the DATA_ROOT default flips — otherwise old cycles get orphaned. Do not delete anything in this step.
+
+### Step 2 — Flip `submit_clyfar.sh` DATA_ROOT default + add archive rsync
+
+In `scripts/submit_clyfar.sh`:
+
+- Change the `DATA_ROOT` default (around line 80, marked with `TODO(policy):`) to `/scratch/general/vast/$USER/clyfar` and drop the `TODO(policy)` comment in the same edit.
+- After the BasinWx export block (after the `STATUS_FORECAST_EXPORT=` line, before the LLM block), add a guarded rsync that copies the **archive subset** to Cottonwood:
+
+  Files to copy: `$DATA_ROOT/dailymax/`, `$DATA_ROOT/clyfar*_df.parquet` (just the aggregated ones if size-sensitive; see `STORAGE-GUIDE.md` archive list), `$FIG_ROOT/heatmaps/`, and any `metadata.json` in the run root.
+
+  Target: `$CLYFAR_ARCHIVE_BASE/archive/$INIT_TIME/` where `CLYFAR_ARCHIVE_BASE` defaults to `/uufs/chpc.utah.edu/common/home/lawson-group6/clyfar` (matching `storage_inventory.sh`).
+
+  The rsync block must:
+  - First `df -hT "$CLYFAR_ARCHIVE_BASE"` and `continue` (i.e., `STATUS_ARCHIVE=SKIPPED reason=mount_faulted`) if the volume is unmounted on this node. Do not fail the job — the science output is already on scratch.
+  - Emit a `STATUS_ARCHIVE=SUCCESS|FAILED|SKIPPED` marker so triage rg patterns can find it.
+  - Be guardable with `CLYFAR_SKIP_ARCHIVE=1` for ad-hoc / dry-run cases that own their own destination.
+
+- Also update the "Output locations:" trailing echo to reflect the new defaults.
+
+Do **not** change anything about `LOG_DIR` (it still lives in `$HOME/logs/basinwx`, which is fine — logs are small and convenient there) or the cron command body in `HIBERNATION.md`.
+
+### Step 3 — Add `scripts/reforecast_one.sh` (smallest useful dry-run wrapper)
+
+A thin wrapper that exercises the new flow with safety rails. Pseudocode:
+
+```bash
+#!/usr/bin/env bash
+# Usage: scripts/reforecast_one.sh YYYYMMDDHH [scratch-subdir]
+# Submits a single historical cycle with uploads disabled and an
+# isolated scratch DATA_ROOT, so multiple dry-runs don't collide.
+
+set -euo pipefail
+INIT="${1:?INIT_TIME (YYYYMMDDHH) required}"
+SUBDIR="${2:-dryrun-$(date -u +%Y%m%d_%H%M%S)}"
+ROOT="/scratch/general/vast/$USER/clyfar/reforecast/$SUBDIR/$INIT"
+
+mkdir -p "$ROOT"
+cd ~/gits/clyfar
+
+CLYFAR_ENABLE_UPLOAD=0 \
+CLYFAR_SKIP_ARCHIVE=1 \
+DATA_ROOT="$ROOT/data" \
+FIG_ROOT="$ROOT/figures" \
+EXPORT_DIR="$ROOT/basinwx_export" \
+  sbatch scripts/submit_clyfar.sh "$INIT" --no-retry
+```
+
+Notes for the cold-start session:
+
+- `--no-retry` is deliberate for dry-runs: a 404 on historical GEFS should fail fast, not resubmit on a 30-minute delay for hours.
+- `CLYFAR_SKIP_ARCHIVE=1` is the dry-run-only switch; production runs leave it unset so Step 2's rsync fires.
+- Pick `SUBDIR` names that are meaningful (`smoke-2024010100`, `winter2425-batch1`) so the scratch tree is browsable.
+
+### Step 4 — Smoke 2–3 historical cycles
+
+Recommended cycle selection (good obs coverage, no live-upload risk, span dynamics):
+
+- `2024010100` — already named in `chpc-v106-dry-run.md` as the first safe init; matches what's been tested before.
+- `2024121500` — winter inversion period, exercises the snow/stagnation code paths.
+- `2025020600` — mid-winter, post-holiday data steady-state.
+
+For each:
+
+```bash
+scripts/reforecast_one.sh 2024010100 smoke-baseline
+scripts/reforecast_one.sh 2024121500 smoke-inversion
+scripts/reforecast_one.sh 2025020600 smoke-midwinter
+```
+
+Verification per cycle (after job completes):
+
+```bash
+ROOT=/scratch/general/vast/$USER/clyfar/reforecast/smoke-baseline/2024010100
+ls -la "$ROOT/data/dailymax/" "$ROOT/figures/heatmaps/" "$ROOT/basinwx_export/" 2>/dev/null
+rg -n "STATUS_FORECAST_EXPORT|STATUS_LLM_STAGE|STATUS_ARCHIVE" \
+  ~/logs/basinwx/clyfar_*.out ~/logs/basinwx/clyfar_*.err | tail -20
+```
+
+Gate: all three cycles must produce a non-empty `dailymax/`, at least one heatmap PNG, a populated `basinwx_export/`, and `STATUS_FORECAST_EXPORT=SUCCESS`. LLM stage success is desirable but **not** a gate (Phase B is non-blocking by design).
+
+### Step 5 — Verify Step 2's rsync path on one *non-dry-run* cycle
+
+The dry-runs in Step 4 set `CLYFAR_SKIP_ARCHIVE=1`, so they exercise everything *except* the archive rsync. Do one extra run *without* the skip, with a clearly-marked dry-run init time, to confirm Cottonwood writes work:
+
+```bash
+# Same wrapper, but unset the skip
+CLYFAR_ENABLE_UPLOAD=0 \
+DATA_ROOT="/scratch/general/vast/$USER/clyfar/reforecast/archive-test/2024010100/data" \
+FIG_ROOT="/scratch/general/vast/$USER/clyfar/reforecast/archive-test/2024010100/figures" \
+EXPORT_DIR="/scratch/general/vast/$USER/clyfar/reforecast/archive-test/2024010100/basinwx_export" \
+CLYFAR_ARCHIVE_BASE=/uufs/chpc.utah.edu/common/home/lawson-group6/clyfar-dryrun \
+  sbatch scripts/submit_clyfar.sh 2024010100 --no-retry
+```
+
+Note `CLYFAR_ARCHIVE_BASE` overridden to a sibling path so the live archive root isn't contaminated with dry-run material. Verify with `ls /uufs/chpc.utah.edu/common/home/lawson-group6/clyfar-dryrun/archive/2024010100/` and clean up after.
+
+### Step 6 — Audit + fix `brc-tools/get_map_obs.py`
+
+Current state: `~/gits/brc-tools/brc_tools/download/get_map_obs.py` has a comment "Save to scratch or temp directory" but writes to `~/gits/brc-tools/data/` (in-repo, under `$HOME`). It runs every 5 minutes via cron.
+
+Two options:
+
+a. **Minimal:** add the same `TODO(policy)` comment style there and leave behavior unchanged. Punts the actual move.
+
+b. **Recommended:** flip it to `${BRC_OBS_DATA_ROOT:-/scratch/general/vast/$USER/obs/maps}` with `os.makedirs(..., exist_ok=True)`. This is a 2-line change. The downstream consumer (whatever reads the obs maps) must be checked — grep for the existing `~/gits/brc-tools/data` path in both repos before flipping.
+
+Either way, this is a **separate PR** in the `brc-tools` repo, not in Clyfar. Do not bundle. The Clyfar cron line that runs `get_map_obs.py` will pick up the new path automatically once the brc-tools PR merges and the conda env doesn't need to change.
+
+If the obs-map output path is consumed by any other downstream tool, that tool needs to be informed in the same PR. Check `brc-tools` and `ubair-website` and `ubwo-fcst` for grep matches against `brc-tools/data`.
+
+### Step 7 — Compose `scripts/reforecast_window.sh` for batch sweeps
+
+Once Steps 4 and 5 pass, the batch driver is straightforward. Sketch:
+
+```bash
+#!/usr/bin/env bash
+# Usage: scripts/reforecast_window.sh START_DATE END_DATE [SUBDIR]
+# Submits all 00/06/12/18Z cycles in [START_DATE, END_DATE] as a SLURM
+# array, with CLYFAR_ENABLE_UPLOAD=0 and an isolated DATA_ROOT per cycle.
+```
+
+Implementation choices to weigh before writing:
+
+- **SLURM job array vs. shell loop:** an array is more polite to the scheduler and gives one `sacct` row per cycle. A shell loop is one-liner-shorter. Default to an array.
+- **Cycle list generation:** Python or bash-based `seq` + `date`. Keep dependency-free if possible (bash + `date -d` arithmetic).
+- **Concurrency cap:** `--array=0-419%8` (or similar) keeps the queue polite. Tune after the smoke run shows per-cycle wallclock.
+- **Failure handling:** the array should not stop on first failure; log STATUS markers per cycle and produce a summary at the end. Keep `--no-retry` so a 404 doesn't churn for hours; reforecast data is historical and either available or not.
+
+The 2024-12-01 → 2025-03-15 winter window is ~420 cycles. A single sbatch array with `%8` concurrency on `notchpeak-shared-short` (8-hour walltime per cycle, current default) gets through it in roughly a day if each cycle finishes in <1 hour.
+
+Migrating reforecast submissions to the owned `lawson-np` partition (14-day walltime, no preemption) is a worthwhile follow-up but is out-of-scope for this handoff — see [`v1.1-roadmap.md`](v1.1-roadmap.md). For the smoke and the first batch, stay on `notchpeak-shared-short` to match current production behavior.
+
+### Step 8 — Open the PR
+
+Once Steps 2–5 are clean and Step 7 is drafted:
+
+```bash
+git push -u origin reforecast-prep
+gh pr create --title "Reforecast prep: flip DATA_ROOT to scratch, add Cottonwood rsync, dry-run wrappers" \
+  --body "..."
+```
+
+PR body should include: the policy citation from `STORAGE-GUIDE.md`, the test-plan checklist (Steps 4 and 5), explicit confirmation that `HIBERNATION.md` cron state is untouched, and a note that `brc-tools/get_map_obs.py` is a separate follow-up.
+
+## Verification gates (cumulative)
+
+- [ ] Step 1: pre-existing `$HOME/basinwx-data/clyfar` inventory written down somewhere (PR description, or a one-off file).
+- [ ] Step 2: `submit_clyfar.sh` `DATA_ROOT` default = scratch; `STATUS_ARCHIVE=` marker present in log output; `CLYFAR_SKIP_ARCHIVE` honored; archive rsync conditional on `df -hT` succeeding.
+- [ ] Step 3: `scripts/reforecast_one.sh` exists, is executable (`chmod +x`), and runs in <2 lines for the trivial case.
+- [ ] Step 4: three smoke cycles produce non-empty `dailymax/`, heatmap PNGs, populated `basinwx_export/`, and `STATUS_FORECAST_EXPORT=SUCCESS` in logs.
+- [ ] Step 5: one archive-test cycle lands under `lawson-group6/clyfar-dryrun/archive/2024010100/` and the dry-run sibling is cleaned up afterward.
+- [ ] Step 6: separate `brc-tools` PR opened (link in the Clyfar PR description), or explicit decision documented to defer.
+- [ ] Step 7: `scripts/reforecast_window.sh` drafted, runs end-to-end on a 2-cycle window (`scripts/reforecast_window.sh 2024010100 2024010106`).
+- [ ] Step 8: PR opened against `main`, all gates green, awaiting review.
+
+## What is explicitly out of scope here
+
+- Resuming live cron submissions. Hibernation stays in effect; that decision is the user's, not the agent's.
+- Changing the SLURM account/partition from `notchpeak-shared-short` to the owned `lawson-np`. Worthwhile, but separate.
+- Cleaning up `$HOME/basinwx-data/clyfar` after the default flips. The PR adds the new path but doesn't move historical data; that's a one-time human decision (keep / archive / delete).
+- Reforecast methodology choices: which window, which init cycles, which scoring rules. This handoff is the engineering plumbing only.
+- Any change to `LLM-GENERATE.sh`, the LLM CLI invocation, or texlive/pandoc plumbing. Reforecast LLM outputs are useful but not gating.
+
+## Pointers
+
+- Storage policy (thin, Clyfar-side): [`STORAGE-GUIDE.md`](STORAGE-GUIDE.md)
+- Canonical CHPC reference (sibling repo): `~/gits/brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md`
+- Earlier dry-run note (overlapping but specific to v1.0.6 smoke): [`chpc-v106-dry-run.md`](chpc-v106-dry-run.md)
+- Pause/resume mechanics: [`../HIBERNATION.md`](../HIBERNATION.md)
+- Long-term v1.1 roadmap: [`v1.1-roadmap.md`](v1.1-roadmap.md)
+- Submit script (the file most edits land in): `scripts/submit_clyfar.sh`
+- Storage audit script (already updated 2026-05-13): `scripts/storage_inventory.sh`

--- a/docs/v1.1-roadmap.md
+++ b/docs/v1.1-roadmap.md
@@ -1,0 +1,35 @@
+# Clyfar v1.1 Roadmap (Dev-mode)
+
+*Imported from `HIBERNATION.md` on 2026-05-13.* No re-curation in this pass — items below are verbatim from the seasonal handoff. A future pass should re-score, dedupe, and tie items to specific epics / issues / branches.
+
+Scoring word: **Leverage** (10 = highest leverage).
+
+## Important / urgent
+
+- **Leverage 10/10** — Freeze operational runtime into a pinned deployment path (non-mutable checkout) and run ops from that path only.
+- **Leverage 10/10** — Split "ops" and "dev" trees (worktree or clone) so development cannot perturb live scheduling environments.
+- **Leverage 9.5/10** — Create a one-command replay harness for historical cycles (download, run, export, validate markers) for deterministic retrospective evaluation.
+- **Leverage 9.5/10** — Add automated scorecard generation (event-based precision/recall, calibration curves, regime slices) from archived forecasts/obs.
+- **Leverage 9/10** — Build a baseline-vs-candidate comparison runner for `v0p9` versus `v1.1+` rule sets with standardized metrics and artifact paths.
+- **Leverage 9/10** — Harden cache lifecycle controls (fresh-cache option, per-job cache isolation, corruption detection, and cleanup hooks).
+- **Leverage 8.5/10** — Add a strict "no upload" dev profile and CI-like local gate checks for export/LLM paths to avoid accidental production side effects.
+- **Leverage 8.5/10** — Create a reproducible data manifest per run (inputs, hashes, versions, run config) for exact reruns and science traceability.
+- **Leverage 8/10** — Define and enforce objective promotion criteria for version bumps (`v1.0.x -> v1.1.0`) tied to measurable gains.
+- **Leverage 8/10** — Consolidate operational triage commands into one script with clear pass/fail output and suggested remediations.
+
+## Cool / useful / fruitful
+
+- **Leverage 7.5/10** — Add lightweight dashboard notebooks/scripts that summarize seasonal skill by episode type (stagnation, frontal clearing, snowpack states).
+- **Leverage 7.5/10** — Introduce parameter sweep tooling for membership-function/rule tuning with reproducible experiment manifests.
+- **Leverage 7/10** — Build a "known-bad cases" benchmark suite to stress-test logic changes before merging.
+- **Leverage 7/10** — Add changelog automation that groups operational, science, and LLM/Ffion impacts per release.
+- **Leverage 6.5/10** — Standardize failure taxonomy and marker vocabulary so postmortems and trend analysis are machine-queryable.
+- **Leverage 6.5/10** — Add synthetic dry-run fixtures for upstream outage simulation (GEFS missing files, upload auth failures, delayed scheduler starts).
+- **Leverage 6/10** — Produce concise architecture diagrams for dataflow and failure domains to speed onboarding of new contributors/agents.
+- **Leverage 6/10** — Create "season startup checklist" and "season shutdown checklist" scripts to reduce manual drift each year.
+
+## Suggested milestone next step
+
+- Keep Clyfar at `1.0.6` as the hibernation baseline.
+- Run 2025/2026 reforecast evaluation with this baseline for the preprint.
+- Start a `v1.1` project board keyed to the top 10 leverage items above.

--- a/scripts/storage_inventory.sh
+++ b/scripts/storage_inventory.sh
@@ -34,12 +34,16 @@ if [[ "${1:-}" == "--clean" ]]; then
 fi
 
 # Storage locations
+# Quotas, mount paths, and CHPC-wide policy live in the team reference:
+#   ~/gits/brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md
+# lawson-group6 is the current active archive store (group5 has shown autofs
+# faults on some notch* nodes). Override CLYFAR_ARCHIVE_BASE to retarget.
 HERBIE_CACHE="${CLYFAR_HERBIE_CACHE:-$HOME/gits/clyfar/data/herbie_cache}"
-SCRATCH_TEST="/scratch/general/vast/clyfar_test"
-SCRATCH_PROD="/scratch/general/vast/clyfar"
+SCRATCH_TEST="${CLYFAR_SCRATCH_TEST:-/scratch/general/vast/$USER/clyfar_test}"
+SCRATCH_PROD="${CLYFAR_SCRATCH_PROD:-/scratch/general/vast/$USER/clyfar}"
 HOME_DATA="$HOME/basinwx-data/clyfar"
 TMP_CACHE="/tmp/clyfar_herbie"
-ARCHIVE_BASE="/uufs/chpc.utah.edu/common/home/lawson-group5/clyfar"
+ARCHIVE_BASE="${CLYFAR_ARCHIVE_BASE:-/uufs/chpc.utah.edu/common/home/lawson-group6/clyfar}"
 
 # Helper: Get directory size (returns "0" if doesn't exist)
 get_size() {
@@ -93,11 +97,33 @@ days_since_access() {
     fi
 }
 
+# Helper: warn (don't fail) if the archive base parent volume is not mounted on this node.
+# Cottonwood lawson-group{4,5,6} are autofs-triggered and can silently fault per-node;
+# a script hardcoding one of them would otherwise no-op invisibly.
+check_archive_mount() {
+    local base="$1"
+    local volume
+    # Extract /uufs/chpc.utah.edu/common/home/lawson-groupN from the archive base
+    volume=$(echo "$base" | sed -E 's|(/uufs/chpc\.utah\.edu/common/home/lawson-group[0-9]+).*|\1|')
+    if [[ "$volume" == "$base" || -z "$volume" ]]; then
+        return 0  # Not a recognised group path; skip check.
+    fi
+    if ! df -hT "$volume" >/dev/null 2>&1; then
+        echo -e "${YELLOW}[!] WARNING: archive volume $volume is not mounted on $(hostname).${NC}"
+        echo -e "${YELLOW}    Autofs may have faulted; try a different node, or set CLYFAR_ARCHIVE_BASE${NC}"
+        echo -e "${YELLOW}    to another lawson-group{4,5,6} path. Continuing with local inventory.${NC}"
+        echo ""
+    fi
+}
+
 # Print header
 echo ""
 echo -e "${BLUE}=== CLYFAR STORAGE INVENTORY ===${NC}"
 echo "Date: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+echo "Archive base: $ARCHIVE_BASE"
 echo ""
+
+check_archive_mount "$ARCHIVE_BASE"
 
 # EPHEMERAL
 echo -e "${YELLOW}EPHEMERAL (auto-wiped on reboot):${NC}"
@@ -109,8 +135,8 @@ fi
 echo ""
 
 # SCRATCH
-echo -e "${YELLOW}SCRATCH (60-day auto-purge, 50TB quota):${NC}"
-echo "  Policy: Files not accessed for >60 days are deleted weekly"
+echo -e "${YELLOW}SCRATCH (60-day atime-based auto-purge):${NC}"
+echo "  Files not accessed for >60 days are deleted automatically."
 echo ""
 
 for scratch_dir in "$SCRATCH_TEST" "$SCRATCH_PROD"; do
@@ -171,7 +197,7 @@ fi
 echo ""
 
 # HOME
-echo -e "${YELLOW}HOME (permanent, 7.3 GiB quota):${NC}"
+echo -e "${YELLOW}HOME (permanent, no auto-purge):${NC}"
 home_used=$(df -h ~ 2>/dev/null | tail -1 | awk '{print $3}')
 home_avail=$(df -h ~ 2>/dev/null | tail -1 | awk '{print $4}')
 home_pct=$(df -h ~ 2>/dev/null | tail -1 | awk '{print $5}')
@@ -185,7 +211,7 @@ fi
 echo ""
 
 # ARCHIVE
-echo -e "${YELLOW}ARCHIVE (permanent, 37 TiB total across lawson-group4/5/6):${NC}"
+echo -e "${YELLOW}ARCHIVE (Cottonwood lawson-group{4,5,6}, no auto-purge):${NC}"
 if [[ -d "$ARCHIVE_BASE" ]]; then
     echo "  $ARCHIVE_BASE"
     echo "    Size: $(get_size "$ARCHIVE_BASE")"

--- a/scripts/submit_clyfar.sh
+++ b/scripts/submit_clyfar.sh
@@ -75,6 +75,9 @@ conda activate clyfar-nov2025 || {
 
 # Set paths (overridable for isolated test runs)
 CLYFAR_DIR="${CLYFAR_DIR:-$HOME/gits/clyfar}"
+# TODO(policy): DATA_ROOT defaults to $HOME, which contradicts the scratch-first
+# storage policy in docs/STORAGE-GUIDE.md. Flip the default to
+# /scratch/general/vast/$USER/clyfar with a post-run rsync to lawson-group6.
 DATA_ROOT="${DATA_ROOT:-$HOME/basinwx-data/clyfar}"
 FIG_ROOT="${FIG_ROOT:-$DATA_ROOT/figures}"
 EXPORT_DIR="${EXPORT_DIR:-$DATA_ROOT/basinwx_export}"


### PR DESCRIPTION
## Summary

- **`docs/STORAGE-GUIDE.md`**: rewritten as a thin Clyfar-specific doc that defers to `~/gits/brc-knowledge/scholarium/reference-base/resources/chpc-team-resource-inventory.md` as the canonical CHPC reference. Drops drift-prone quota numbers (home was stated as 7.3 GiB vs. actual 2 TiB; group5 was stated as 16 TiB vs. actual 30 TiB; group4 and group6 absent). Keeps Clyfar-specific content: output tree, archive-vs-delete table, quick commands. Archive example now points at `lawson-group6` (active store; group5 had autofs faults on `notch392` 2026-05-13).
- **`HIBERNATION.md`**: trimmed from 160 to ~56 lines, runbook only. The 16-item v1.1 dev-mode roadmap moves verbatim to `docs/v1.1-roadmap.md`. The regeneratable version/tag/label snapshot is dropped.
- **`scripts/storage_inventory.sh`**: `ARCHIVE_BASE` now configurable via `CLYFAR_ARCHIVE_BASE` with a `lawson-group6` default; scratch defaults match what scripts actually create (`/scratch/general/vast/$USER/clyfar`); new `check_archive_mount` helper warns (without failing) when the configured Cottonwood volume is autofs-faulted on the current node.
- **`scripts/submit_clyfar.sh`**: single `TODO(policy)` comment above the `DATA_ROOT` default flagging that it routes active runs into `$HOME` against the stated scratch-first policy. **No behavior change**; the actual flip + post-run rsync is the first task in the cold-start handoff.
- **`docs/handoff-reforecast-prep.md`** (new): eight-step cold-start plan to take Clyfar from "hibernating with a known storage-policy violation" to "able to run reforecast sweeps end-to-end on scratch with durable outputs on Cottonwood". Explicit verification gates and out-of-scope list.

## Why this PR replaces a bypass push

The same work landed on `main` as a single consolidated commit (`9f71927`) via a bypass push, which has now been reverted (`183fc66`) so the work can go through review here. The five commits on this branch are the same diff split by concern.

## Test plan

- [ ] `docs/STORAGE-GUIDE.md` no longer hardcodes any quota number; pointer to brc-knowledge inventory is present and the linked file exists.
- [ ] `wc -l HIBERNATION.md` ≈ 56 (down from 160); the cron command body inside the runbook is byte-identical to pre-trim so cron still parses cleanly.
- [ ] `bash -n scripts/storage_inventory.sh` exits 0.
- [ ] `CLYFAR_ARCHIVE_BASE=/uufs/chpc.utah.edu/common/home/lawson-group6/clyfar scripts/storage_inventory.sh` prints the configured archive base; mount smoke-test warns when running on a node where group6 is autofs-faulted; exit code stays 0.
- [ ] `grep -n "TODO(policy)" scripts/submit_clyfar.sh` shows exactly one new comment line above `DATA_ROOT=`; submit script execution behavior is unchanged.
- [ ] `docs/v1.1-roadmap.md` contains the 16 leverage items previously in HIBERNATION.md, unmodified.
- [ ] `HIBERNATION.md` cron-state block (the "Current intended cron state" section) is unchanged so the seasonal pause stays in effect.

## Out of scope

- The `DATA_ROOT` flip itself, post-run Cottonwood rsync, and reforecast dry-runs (covered in `docs/handoff-reforecast-prep.md`).
- Any `brc-tools/get_map_obs.py` change (separate PR in the sibling repo).
- Resuming live cron submissions; hibernation stays in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)