### PR TITLE
[codex] defer synoptic import and add snow fallback

### DIFF
--- a/obs/obsdata.py
+++ b/obs/obsdata.py
@@ -8,8 +8,6 @@ from metpy.units import units
 import numpy as np
 import pandas as pd
 
-import synoptic.services as ss
-
 import utils.utils as utils
 from utils.lookups import Lookup
 
@@ -57,8 +55,19 @@ class ObsData:
 
         self.df = self.create_df()
 
+    @staticmethod
+    def _synoptic_services():
+        try:
+            import synoptic.services as ss
+        except Exception as exc:
+            raise RuntimeError(
+                "Synoptic services are unavailable for observation retrieval."
+            ) from exc
+        return ss
+
     def create_metadata_df(self, stids=None):
         # TODO - check this finds all stations within certain time, not just recent
+        ss = self._synoptic_services()
         if stids is None:
             df_meta = ss.stations_metadata(radius=self.radius_str) #, recent=self.recent)
         else:
@@ -81,6 +90,7 @@ class ObsData:
             pd.DataFrame: dataframe of observation data
 
         """
+        ss = self._synoptic_services()
         df_list = []
         for stid in self.stids:
             print("Loading data for station", stid)

--- a/preprocessing/representative_nwp_values.py
+++ b/preprocessing/representative_nwp_values.py
@@ -21,6 +21,7 @@ from preprocessing.representative_obs import do_repval_snow, \
 
 LOCAL_SOLAR_TIMEZONE = "America/Denver"
 SOLAR_PERSISTENCE_CUTOFF_H = 240
+logger = logging.getLogger(__name__)
 
 
 def _to_utc_index(index_like) -> pd.DatetimeIndex:
@@ -372,12 +373,18 @@ def do_nwpval_snow(init_dt_naive: datetime.datetime,
         repr_val = 0
 
         # Load data via Synoptic Weather API (and SynopticPy)
-        recent_df = download_most_recent("snow", 7,
-                                            snow_stids).df
-        repr_snow = do_repval_snow(recent_df, snow_stids)
+        try:
+            recent_df = download_most_recent("snow", 7, snow_stids).df
+            repr_snow = do_repval_snow(recent_df, snow_stids)
 
-        # Use most recent value for "DA"
-        repr_val = float(repr_snow.loc[repr_snow.index[-1]].squeeze())
+            # Use most recent value for "DA"
+            repr_val = float(repr_snow.loc[repr_snow.index[-1]].squeeze())
+        except Exception as exc:
+            logger.warning(
+                "Falling back to zero snow offset because recent observations "
+                "could not be loaded: %s",
+                exc,
+            )
 
         # Offset the timeseries by the representative value vs original value
         offset = float(snow_ts.isel(time=0).sde.values.squeeze()) - repr_val

--- a/tests/test_synoptic_import_fallback.py
+++ b/tests/test_synoptic_import_fallback.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+def test_representative_nwp_values_imports_without_synoptic_side_effect(tmp_path):
+    fake_pkg = tmp_path / "synoptic"
+    fake_pkg.mkdir()
+    (fake_pkg / "__init__.py").write_text("")
+    (fake_pkg / "services.py").write_text("raise RuntimeError('synoptic import should not run')\n")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), str(repo_root)])
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import preprocessing.representative_nwp_values"],
+        cwd=str(repo_root),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_do_nwpval_snow_falls_back_when_recent_obs_fail(monkeypatch):
+    pytest.importorskip("xarray")
+
+    import datetime as dt
+    import xarray as xr
+
+    from preprocessing import representative_nwp_values as mod
+
+    def fake_process_nwp_timeseries(*args, **kwargs):
+        times = [dt.datetime(2026, 1, 6, 18, 0), dt.datetime(2026, 1, 7, 0, 0)]
+        return xr.Dataset(
+            {"sde": ("time", np.array([1.0, 1.5], dtype=float))},
+            coords={"time": times},
+        )
+
+    def fake_download_most_recent(*args, **kwargs):
+        raise RuntimeError("synoptic unavailable")
+
+    monkeypatch.setattr(mod, "process_nwp_timeseries", fake_process_nwp_timeseries)
+    monkeypatch.setattr(mod, "download_most_recent", fake_download_most_recent)
+
+    snow_ts = mod.do_nwpval_snow(
+        dt.datetime(2026, 1, 6, 18, 0),
+        start_h=0,
+        max_h=3,
+        masks={"0p25": None, "0p5": None},
+        delta_h=3,
+        initialise_with_obs=True,
+    )
+
+    assert float(snow_ts.isel(time=0).sde.values.squeeze()) == 0.0
+    assert float(snow_ts.isel(time=1).sde.values.squeeze()) == 500.0


### PR DESCRIPTION
## What changed
- Deferred `synoptic.services` import in `obs/obsdata.py` until observation retrieval is actually needed.
- Wrapped the snow representative-observation bootstrap in a warning + zero-offset fallback so replay startup does not die on transient Synoptic failures.
- Added regression coverage for both the import-time failure mode and the snow fallback path.

## Why
- The replay job was failing during module import, before any forecast artifacts were produced, because Synoptic token validation happened too early.

## Checks
- `env PYTHONPATH=. pytest -q tests/test_synoptic_import_fallback.py`
- `env PYTHONPATH=. pytest -q tests/test_solar_time_logic.py tests/test_preprocessing_dataframe.py`
- `python -m py_compile obs/obsdata.py preprocessing/representative_nwp_values.py tests/test_synoptic_import_fallback.py`