### PR TITLE
fix: fan out BasinWx uploads to all configured hosts

### DIFF
--- a/export/to_basinwx.py
+++ b/export/to_basinwx.py
@@ -10,7 +10,13 @@ Generates 6 data products (up to 96 JSON files per forecast run):
 
 Environment variables required:
 - DATA_UPLOAD_API_KEY: API key for BasinWx upload endpoint
-- BASINWX_API_URL: Base URL for BasinWx API (default: https://basinwx.com)
+- BASINWX_API_URLS: Comma-separated BasinWx hosts. First is primary (its failure
+  fails the upload); the rest are best-effort mirrors that warn on failure.
+  e.g. "https://basinwx.com,https://basinwx.dev"
+- BASINWX_API_URL: Legacy singular form, still honoured as a fallback so
+  un-updated CHPC cron jobs keep working. Sends to that one host only.
+
+See resolve_upload_urls() for the full resolution order.
 
 Created by: John Lawson & Claude
 Note: Multi-agent development environment - verify changes across repos
@@ -33,7 +39,7 @@ from utils.versioning import get_clyfar_version
 
 # Import from brc-tools (installed as editable package)
 try:
-    from brc_tools.download.push_data import send_json_to_server
+    from brc_tools.download.push_data import send_json_to_all, load_config_urls
 except ImportError as e:
     raise ImportError(
         "Cannot import brc_tools. Ensure it's installed: "
@@ -723,6 +729,73 @@ def export_all_products(
     return results
 
 
+def resolve_upload_urls() -> List[str]:
+    """Resolve the list of BasinWx hosts to upload to.
+
+    First entry is the primary (its failure fails the upload); the rest are
+    best-effort mirrors. Resolution order, first hit wins:
+
+      1. BASINWX_API_URLS  — comma-separated, the fan-out variable
+      2. BASINWX_API_URL   — singular legacy variable, kept so CHPC cron jobs
+                             that have not been updated keep working
+      3. brc_tools.load_config_urls() — ~/.config/ubair-website/website_urls
+      4. https://basinwx.com
+
+    Historically this module only ever read (2), which is why `images` and
+    `llm_outlooks` reached basinwx.com alone and never appeared on basinwx.dev
+    — the rehearsal mirror was blind to them. See clyfar#20.
+    """
+    env_plural = os.getenv('BASINWX_API_URLS', '').strip()
+    if env_plural:
+        urls = [u.strip().rstrip('/') for u in env_plural.split(',') if u.strip()]
+        if urls:
+            return urls
+
+    env_singular = os.getenv('BASINWX_API_URL', '').strip()
+    if env_singular:
+        return [env_singular.rstrip('/')]
+
+    try:
+        _, urls = load_config_urls()
+        if urls:
+            return urls
+    except Exception as e:
+        logger.debug(f"load_config_urls() unavailable, falling back to default: {e}")
+
+    return ['https://basinwx.com']
+
+
+def _upload_file_to_basinwx(filepath: str, data_type: str, *, label: str = 'file') -> bool:
+    """Upload one file to every configured BasinWx host.
+
+    Delegates to brc_tools.send_json_to_all, which posts multipart with the MIME
+    type inferred from the extension — so this carries JSON, PNG and PDF/markdown
+    equally. It raises if the *primary* host fails and warns if a mirror does.
+
+    Returns True/False rather than propagating, preserving the contract the
+    callers in this module already rely on.
+    """
+    api_key = os.getenv('DATA_UPLOAD_API_KEY')
+    if not api_key:
+        logger.warning(f"DATA_UPLOAD_API_KEY not set, skipping {label} upload")
+        return False
+
+    urls = resolve_upload_urls()
+
+    try:
+        send_json_to_all(urls, filepath, data_type, api_key)
+        logger.debug(
+            f"Uploaded {os.path.basename(filepath)} to {len(urls)} host(s): {', '.join(urls)}"
+        )
+        return True
+
+    except Exception as e:
+        # send_json_to_all raises only when the PRIMARY host fails; mirror
+        # failures are warned about internally and do not reach here.
+        logger.error(f"Failed to upload {label} {filepath} to primary host: {e}")
+        return False
+
+
 def _upload_to_basinwx(filepath: str, data_type: str) -> bool:
     """Upload JSON file to BasinWx API.
 
@@ -733,26 +806,7 @@ def _upload_to_basinwx(filepath: str, data_type: str) -> bool:
     Returns:
         True if upload succeeded, False otherwise
     """
-    api_key = os.getenv('DATA_UPLOAD_API_KEY')
-    if not api_key:
-        logger.warning("DATA_UPLOAD_API_KEY not set, skipping upload")
-        return False
-
-    api_url = os.getenv('BASINWX_API_URL', 'https://basinwx.com')
-
-    try:
-        send_json_to_server(
-            server_address=api_url,
-            fpath=filepath,
-            file_data=data_type,  # data_type is 'forecasts', not JSON content
-            API_KEY=api_key
-        )
-        logger.debug(f"Uploaded {os.path.basename(filepath)} to {api_url}")
-        return True
-
-    except Exception as e:
-        logger.error(f"Failed to upload {filepath}: {e}")
-        return False
+    return _upload_file_to_basinwx(filepath, data_type, label='JSON')
 
 
 def _parallel_upload_jsons(filepaths: List[str], data_type: str, max_workers: int = 8) -> int:
@@ -819,27 +873,17 @@ def _upload_single_png(png_path: str, session, upload_url: str, headers: dict) -
 def upload_png_to_basinwx(png_path: str) -> bool:
     """Upload a PNG image to BasinWx API (standalone version).
 
+    Fans out to every configured host — see resolve_upload_urls(). Previously
+    this posted to the singular BASINWX_API_URL only, so images never reached
+    basinwx.dev (clyfar#20).
+
     Args:
         png_path: Path to PNG file
 
     Returns:
         True if upload succeeded, False otherwise
     """
-    import requests
-    import socket
-
-    api_key = os.getenv('DATA_UPLOAD_API_KEY')
-    if not api_key:
-        logger.warning("DATA_UPLOAD_API_KEY not set, skipping PNG upload")
-        return False
-
-    api_url = os.getenv('BASINWX_API_URL', 'https://basinwx.com')
-    upload_url = f"{api_url}/api/upload/images"
-    hostname = socket.getfqdn()
-    headers = {'x-api-key': api_key, 'x-client-hostname': hostname}
-
-    with requests.Session() as session:
-        return _upload_single_png(png_path, session, upload_url, headers)
+    return _upload_file_to_basinwx(png_path, 'images', label='PNG')
 
 
 def upload_pdf_to_basinwx(pdf_path: str) -> bool:
@@ -857,46 +901,20 @@ def upload_pdf_to_basinwx(pdf_path: str) -> bool:
 def upload_outlook_to_basinwx(file_path: str) -> bool:
     """Upload an LLM outlook file (PDF or markdown) to BasinWx API.
 
+    Fans out to every configured host — see resolve_upload_urls(). Previously
+    this posted to the singular BASINWX_API_URL only, so llm_outlooks never
+    reached basinwx.dev (clyfar#20).
+
+    MIME type is inferred from the extension inside brc_tools, which is the same
+    path the outlook .md files already travel from push_outlook.py.
+
     Args:
         file_path: Path to PDF or markdown file
 
     Returns:
         True if upload succeeded, False otherwise
     """
-    import requests
-    import socket
-
-    api_key = os.getenv('DATA_UPLOAD_API_KEY')
-    if not api_key:
-        logger.warning("DATA_UPLOAD_API_KEY not set, skipping outlook upload")
-        return False
-
-    api_url = os.getenv('BASINWX_API_URL', 'https://basinwx.com')
-    upload_url = f"{api_url}/api/upload/llm_outlooks"
-    hostname = socket.getfqdn()
-    headers = {'x-api-key': api_key, 'x-client-hostname': hostname}
-
-    # Detect MIME type from extension
-    ext = os.path.splitext(file_path)[1].lower()
-    mime_types = {'.pdf': 'application/pdf', '.md': 'text/markdown'}
-    mime_type = mime_types.get(ext, 'application/octet-stream')
-
-    try:
-        with requests.Session() as session:
-            with open(file_path, 'rb') as f:
-                files = {'file': (os.path.basename(file_path), f, mime_type)}
-                response = session.post(upload_url, files=files, headers=headers, timeout=60)
-
-            if response.status_code == 200:
-                logger.info(f"Uploaded outlook: {os.path.basename(file_path)}")
-                return True
-            else:
-                logger.error(f"Outlook upload failed ({response.status_code}): {response.text}")
-                return False
-
-    except Exception as e:
-        logger.error(f"Failed to upload outlook {file_path}: {e}")
-        return False
+    return _upload_file_to_basinwx(file_path, 'llm_outlooks', label='outlook')
 
 
 def upload_json_to_basinwx(filepath: str, data_type: str = "forecasts") -> bool:
@@ -1018,29 +1036,51 @@ def export_figures_to_basinwx(
             logger.warning("DATA_UPLOAD_API_KEY not set, skipping PNG uploads")
             return results
 
-        api_url = os.getenv('BASINWX_API_URL', 'https://basinwx.com')
-        upload_url = f"{api_url}/api/upload/images"
+        # Fan out to every configured host. This is the bulk images path — the
+        # one a forecast run actually exercises — and it read the singular
+        # BASINWX_API_URL, which is why basinwx.dev never saw any images
+        # (clyfar#20). One session per host preserves connection pooling.
+        urls = resolve_upload_urls()
         hostname = socket.getfqdn()
         headers = {'x-api-key': api_key, 'x-client-hostname': hostname}
 
-        logger.info(f"Uploading {len(all_pngs)} PNGs with {max_workers} workers...")
+        for idx, base_url in enumerate(urls):
+            role = "PRIMARY" if idx == 0 else "MIRROR"
+            upload_url = f"{base_url}/api/upload/images"
 
-        # Use a shared session for connection pooling and proper cleanup
-        session = requests.Session()
-        try:
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = {
-                    executor.submit(_upload_single_png, p, session, upload_url, headers): p
-                    for p in all_pngs
-                }
-                success = 0
-                for future in as_completed(futures):
-                    if future.result():
-                        success += 1
-            logger.info(f"Uploaded {success}/{len(all_pngs)} PNGs")
-        finally:
-            # Explicitly close session to ensure all connections are cleaned up
-            session.close()
+            logger.info(
+                f"[{role} {base_url}] Uploading {len(all_pngs)} PNGs "
+                f"with {max_workers} workers..."
+            )
+
+            # Use a shared session for connection pooling and proper cleanup
+            session = requests.Session()
+            try:
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    futures = {
+                        executor.submit(_upload_single_png, p, session, upload_url, headers): p
+                        for p in all_pngs
+                    }
+                    success = 0
+                    for future in as_completed(futures):
+                        if future.result():
+                            success += 1
+                logger.info(f"[{role} {base_url}] Uploaded {success}/{len(all_pngs)} PNGs")
+
+                # Primary failures are loud; mirror failures must never fail the run.
+                if success < len(all_pngs):
+                    shortfall = len(all_pngs) - success
+                    if role == "PRIMARY":
+                        logger.error(
+                            f"[{role} {base_url}] {shortfall} PNG upload(s) failed"
+                        )
+                    else:
+                        logger.warning(
+                            f"WARNING mirror PNG uploads failed: {shortfall} to {base_url}"
+                        )
+            finally:
+                # Explicitly close session to ensure all connections are cleaned up
+                session.close()
 
     # Upload outlook files (PDFs + markdown) to llm_outlooks endpoint
     if upload and all_outlook_files:

--- a/tests/test_basinwx_upload_urls.py
+++ b/tests/test_basinwx_upload_urls.py
@@ -1,0 +1,82 @@
+"""Tests for BasinWx upload URL resolution (clyfar#20).
+
+`export/to_basinwx.py` previously read only the singular BASINWX_API_URL, so every
+product it pushed — images, llm_outlooks, forecast JSON — reached basinwx.com alone
+and never appeared on the basinwx.dev rehearsal mirror.
+
+These pin the resolution order so that regression cannot come back quietly.
+"""
+
+import pytest
+
+# to_basinwx pulls in pandas/numpy/brc_tools; skip cleanly where they are absent.
+to_basinwx = pytest.importorskip(
+    "export.to_basinwx",
+    reason="requires the full clyfar runtime (pandas, numpy, brc_tools)",
+)
+
+resolve_upload_urls = to_basinwx.resolve_upload_urls
+
+BOTH = "https://basinwx.com,https://basinwx.dev"
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("BASINWX_API_URLS", raising=False)
+    monkeypatch.delenv("BASINWX_API_URL", raising=False)
+
+
+def test_plural_fans_out_and_preserves_order(monkeypatch):
+    """First entry is primary; order matters and must be preserved."""
+    monkeypatch.setenv("BASINWX_API_URLS", BOTH)
+    assert resolve_upload_urls() == ["https://basinwx.com", "https://basinwx.dev"]
+
+
+def test_plural_takes_precedence_over_singular(monkeypatch):
+    monkeypatch.setenv("BASINWX_API_URLS", BOTH)
+    monkeypatch.setenv("BASINWX_API_URL", "https://basinwx.com")
+    assert resolve_upload_urls() == ["https://basinwx.com", "https://basinwx.dev"]
+
+
+def test_plural_tolerates_whitespace_slashes_and_blanks(monkeypatch):
+    monkeypatch.setenv(
+        "BASINWX_API_URLS", " https://basinwx.com/ ,, https://basinwx.dev/ ,"
+    )
+    assert resolve_upload_urls() == ["https://basinwx.com", "https://basinwx.dev"]
+
+
+def test_singular_still_works_for_un_updated_cron(monkeypatch):
+    """CHPC wrappers that only set the legacy var must keep uploading."""
+    monkeypatch.setenv("BASINWX_API_URL", "https://basinwx.com")
+    assert resolve_upload_urls() == ["https://basinwx.com"]
+
+
+def test_blank_plural_falls_through_to_singular(monkeypatch):
+    monkeypatch.setenv("BASINWX_API_URLS", "   ")
+    monkeypatch.setenv("BASINWX_API_URL", "https://basinwx.dev")
+    assert resolve_upload_urls() == ["https://basinwx.dev"]
+
+
+def test_env_beats_config_file(monkeypatch):
+    monkeypatch.setattr(
+        to_basinwx, "load_config_urls", lambda: ("key", ["https://from-config"])
+    )
+    monkeypatch.setenv("BASINWX_API_URLS", "https://from-env")
+    assert resolve_upload_urls() == ["https://from-env"]
+
+
+def test_config_file_used_when_no_env(monkeypatch):
+    monkeypatch.setattr(
+        to_basinwx,
+        "load_config_urls",
+        lambda: ("key", ["https://cfg-a", "https://cfg-b"]),
+    )
+    assert resolve_upload_urls() == ["https://cfg-a", "https://cfg-b"]
+
+
+def test_defaults_to_com_when_nothing_configured(monkeypatch):
+    def _raise():
+        raise RuntimeError("no config file")
+
+    monkeypatch.setattr(to_basinwx, "load_config_urls", _raise)
+    assert resolve_upload_urls() == ["https://basinwx.com"]


### PR DESCRIPTION
Closes #20.

## Problem

`export/to_basinwx.py` read the **singular** `BASINWX_API_URL` (default `https://basinwx.com`) at every upload site, so everything this module pushes reached `.com` alone. Measured on linode-dev over the entire pm2 log: **`images` 0 uploads, `llm_outlooks` 0 uploads — ever.**

`basinwx.dev` is the rehearsal mirror where stakeholder demos happen and where changes are validated before promotion to `ops`. With these dark it cannot rehearse anything that depends on them, and it would run blind through ozone season.

## Four sites fixed

| Function | Product | Was |
|---|---|---|
| `_upload_to_basinwx()` | forecast JSON | single host |
| `upload_png_to_basinwx()` | standalone image | single host |
| `upload_outlook_to_basinwx()` | PDF / markdown outlook | single host |
| `export_all_products()` | **bulk PNG path** — what a real forecast run exercises | single host |

That last one is the important one and the easiest to miss — it builds its own `upload_url` inline rather than calling the helper.

## New `resolve_upload_urls()`

First hit wins:

1. `BASINWX_API_URLS` — comma-separated, the fan-out variable
2. `BASINWX_API_URL` — legacy singular, **kept deliberately** so un-updated CHPC cron jobs keep working mid-season
3. `brc_tools.load_config_urls()` — `~/.config/ubair-website/website_urls`
4. `https://basinwx.com`

## Failure semantics

Matches `brc-tools` exactly: **first host is primary and its failure fails the upload; the rest are best-effort mirrors that log a WARNING.** `.dev` being down can never break a production forecast run.

The three single-file paths now delegate to `brc_tools.send_json_to_all`, which already posts multipart with the MIME type inferred from the extension — the same path `push_outlook.py` uses for `.md` — so PNG and PDF no longer need bespoke upload code. That deletes more than it adds. The bulk PNG path keeps its `ThreadPoolExecutor` and per-host `requests.Session` for connection pooling, looping hosts on the outside.

`export/upload_batch.py` is **deliberately untouched** — it takes `--server` explicitly, so it's a manual tool where the operator names the destination, not part of automated fan-out.

## ⚠️ This is the code half only

Uploads will not start reaching `.dev` until the CHPC cron wrappers export the plural variable:

```bash
export BASINWX_API_URLS="https://basinwx.com,https://basinwx.dev"
```

`CHPC-LLM-PROD.sh` and `scripts/submit_clyfar.sh` currently reference the singular form. I left those alone since they're CHPC operational config and yours to sequence — happy to do them in a follow-up if you'd rather.

## Testing

`tests/test_basinwx_upload_urls.py` covers all 8 resolution branches: plural precedence, whitespace/trailing-slash/blank tolerance, singular fallback, blank-plural fallthrough, config-file fallback, env-beats-config, and the final default.

**Honest caveat:** I could not execute the suite — pandas/numpy/brc_tools aren't installed where I was working, and the test `importorskip`s accordingly. I verified the resolver logic by extracting the function and exercising all 8 branches standalone (all pass), and both changed files pass `py_compile`. **The upload paths themselves are unexercised** — worth one manual run against a `.dev`-only `BASINWX_API_URLS` before trusting it in the ozone-season cron.

## Verification once deployed

From the receiving box:

```bash
grep -a 'File uploaded' ~/.pm2/logs/basinwx-dev-out.log \
  | grep -ao 'Type: [a-z-]*' | sort | uniq -c
```

`images` and `llm_outlooks` should appear with non-zero counts. Note `.dev` ingests over ordinary public HTTPS (CHPC POSTs straight to `https://www.basinwx.dev`), unlike prod's SSH tunnel — so no tunnel setup is needed for the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)